### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/docs/standards/structure.rst
+++ b/docs/standards/structure.rst
@@ -52,7 +52,7 @@ Installation
 The Installation section needs to be reasonably comprehensive.
 
 Example: `Aldryn Jobs installation
-<http://aldryn-jobs.readthedocs.org/en/latest/introduction/installation.html>`_.
+<https://aldryn-jobs.readthedocs.io/en/latest/introduction/installation.html>`_.
 
 The Installation section is *required*.
 
@@ -67,7 +67,7 @@ steps you'd expect the site administrator to do to set it up within the Django a
 the ordinary content editor.
 
 Example: `Aldryn Jobs basic usage
-<http://aldryn-jobs.readthedocs.org/en/latest/introduction/basic_usage.html>`_.
+<https://aldryn-jobs.readthedocs.io/en/latest/introduction/basic_usage.html>`_.
 
 Unless these steps are unnecessary, or are completely obvious, this section is *required*.
 
@@ -103,7 +103,7 @@ The topics section is optional, but recommended if APIs and models are complex e
 several options that need to spelled out.
 
 Example: `Aldryn Jobs reference
-<http://aldryn-jobs.readthedocs.org/en/latest/reference/index.html>`_.
+<https://aldryn-jobs.readthedocs.io/en/latest/reference/index.html>`_.
 
 ***********************
 Development & community
@@ -136,9 +136,9 @@ end-user who is not a developer finds it useful.
 .. note::
 
    The ``introduction/basic_usage.rst`` section should have left the system in a state to make this
-   possible. See for example the `Aldryn Jobs documentation <http://aldryn-jobs.readthedocs.org>`_,
+   possible. See for example the `Aldryn Jobs documentation <https://aldryn-jobs.readthedocs.io>`_,
    in which the `Using Aldryn Jobs
-   <http://aldryn-jobs.readthedocs.org/en/latest/user/index.html#using-aldryn-jobs>`_ section
+   <https://aldryn-jobs.readthedocs.io/en/latest/user/index.html#using-aldryn-jobs>`_ section
    assumes that the Introduction has configured the basics in the admin.
 
 The user-facing documentation needs to be written for a *user*, not simply for a developer or

--- a/docs/tutorial/starter_files.rst
+++ b/docs/tutorial/starter_files.rst
@@ -16,8 +16,8 @@ How to use the starter files
 For a brand-new project
 =======================
 
-* Follow the directions for `setting up <http://application-documentation.readthedocs.org>`_ and
-  then `configuring <http://application-documentation.readthedocs.org>`_ your documentation.
+* Follow the directions for `setting up <https://application-documentation.readthedocs.io>`_ and
+  then `configuring <https://application-documentation.readthedocs.io>`_ your documentation.
 
 * ``git clone git@github.com:divio/application-documentation-starter-files.git`` (i.e. the
   repository of starter files) into another directory.


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.
